### PR TITLE
Make /import endpoint wait for YNAB API and make response message more friendly

### DIFF
--- a/src/routes.ts
+++ b/src/routes.ts
@@ -39,9 +39,9 @@ const initRoutes = (app, db) => {
     res.status(200).send(await handleCheckUp(db))
   })
 
-  app.get('/import', (req, res) => {
-    importYNAB(process.env.budgetName ,db)
-    res.status(200).send('sucess')
+  app.get('/import', async (req, res) => {
+    await importYNAB(process.env.budgetName ,db)
+    res.status(200).send('Import Complete!')
   })
 }
 


### PR DESCRIPTION
I noticed when I ran it that the `/import` endpoint returned `success` before the data had finished importing. I thought it didn't work before I realized it was just asynchronous and not waiting for the YNAB API response to come in. Just tweaked the routes to make sure it waits.

I could also add some light error handling for that endpoint, if you like.