### PR TITLE
Add docker image and docker compose support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:latest
+WORKDIR /usr/src/
+RUN git clone https://github.com/vishnubob/wait-for-it.git
+RUN git clone https://github.com/gruberb/YNABDoctor.git
+WORKDIR /usr/src/YNABDoctor
+RUN npm install
+EXPOSE 8080

--- a/README.md
+++ b/README.md
@@ -38,6 +38,14 @@ budgetName=YOUR_BUDGET_NAME
 1. Start Mongo (usually during typing `mongod` in a terminal window)
 2. `npm start`
 
+## Docker
+
+1. Install [Docker](https://www.docker.com/community-edition#/download)
+2. Set `YNAB_ACCESS_TOKEN` and `YNAB_BUDGET_NAME` environment variables. 
+For example: `export YNAB_ACCESS_TOKEN=XXX`
+3. `docker-compose up` or `docker-compose up -d` to background
+4. Access via `localhost:8080`
+
 ## Endpoints
 
 So far there are seven working endpoints.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ budgetName=YOUR_BUDGET_NAME
 2. Set `YNAB_ACCESS_TOKEN` and `YNAB_BUDGET_NAME` environment variables. 
 For example: `export YNAB_ACCESS_TOKEN=XXX`
 3. `docker-compose up` or `docker-compose up -d` to background
-4. Access via `localhost:8080`
+4. Access via `localhost:62818`
 
 ## Endpoints
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,20 @@
+version: "3"
+services:
+  ynabdoctor:
+    image: ynabdoctor
+    container_name: ynabdoctor
+    build: .
+    environment:
+      accessToken: "${YNAB_ACCESS_TOKEN}"
+      mongoUrl: 'mongodb://mongo:27017'
+      mongoDBName: 'YNABDoctor'
+      budgetName: '${YNAB_BUDGET_NAME}'
+    ports:
+      - "8080:8080"
+    command: ["/usr/src/wait-for-it/wait-for-it.sh", "mongo:27017", "--",  "npm", "start"]
+    depends_on: 
+      - mongo
+  mongo:
+    image: mongo
+    container_name: ynabdoctor_mongo
+    restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       mongoDBName: 'YNABDoctor'
       budgetName: '${YNAB_BUDGET_NAME}'
     ports:
-      - "8080:8080"
+      - "62818:8080"
     command: ["/usr/src/wait-for-it/wait-for-it.sh", "mongo:27017", "--",  "npm", "start"]
     depends_on: 
       - mongo


### PR DESCRIPTION
### Summary
This PR adds support for building a docker image and bringing up a mongo and YNABDoctor stack. It should resolve #23 

### Environment Variables
I decided to skip the `dotenv` file pattern in favor of passing environment variables in at runtime. I have chosen to hardcode  `mongoDBName` to `YNABDoctor`. Of course `mongoUrl` is also hardcoded to work within the context of the docker-compose stack.

This adjustment didn't require app changes.

### Dependencies
Other than Docker and environment variables. Nothing should be required to get this running.

Within the container, I used https://github.com/vishnubob/wait-for-it to ensure mongo is ready before YNABDoctor starts.

### Ports
`8080` gets overloaded often, I chose the first commit date `62818` for this project as the port exposed to the host.

### Testing
OS X High Sierra
Docker CE 18.03.1-ce
Compose 1.21.1

Tested 
- `import`
- `networthoverview`
- `reports`
- `spendings`
- `savings`
- `spendingHabits`
- `checkUp?limit=`